### PR TITLE
Remove creating a server.ini file and pass in settings using hiera

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -37,7 +37,7 @@ class hhvm::config (
   validate_string($group)
 
   $default_conf_file = '/etc/default/hhvm'
-  create_resources(config::setting, to_hash_settings({
+  create_resources(hhvm::config::setting, to_hash_settings({
     'RUN_AS_USER' => $user,
     'RUN_AS_GROUP' => $group
   }, $default_conf_file), {
@@ -46,7 +46,7 @@ class hhvm::config (
   })
 
   $php_ini = '/etc/hhvm/php.ini'
-  create_resources(config::setting, to_hash_settings($settings, $php_ini), {
+  create_resources(hhvm::config::setting, to_hash_settings($settings, $php_ini), {
     file   => $php_ini,
     notify => Service['hhvm']
   })

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -25,7 +25,6 @@
 class hhvm::config (
   $user     = 'www-data',
   $group    = 'www-data',
-  $port     = 9000,
   $settings = {}
 ) {
 
@@ -36,7 +35,6 @@ class hhvm::config (
   validate_hash($settings)
   validate_string($user)
   validate_string($group)
-  validate_string($port)
 
   $default_conf_file = '/etc/default/hhvm'
   create_resources(config::setting, to_hash_settings({
@@ -46,13 +44,6 @@ class hhvm::config (
     file   => $default_conf_file,
     notify => Service['hhvm']
   })
-
-  config::setting { 'hhvm-server-ini':
-    file   => '/etc/hhvm/server.ini',
-    key    => 'hhvm.server.port',
-    value  => $port,
-    notify => Service['hhvm']
-  }
 
   $php_ini = '/etc/hhvm/php.ini'
   create_resources(config::setting, to_hash_settings($settings, $php_ini), {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,8 @@ class hhvm (
 
   validate_bool($manage_repos)
   validate_hash($settings)
+  
+  $_settings = hiera_hash('hhvm::settings',$settings)
 
   if $manage_repos {
     anchor { 'hhvm::repo': } ->
@@ -39,7 +41,7 @@ class hhvm (
   anchor { 'hhvm::begin': } ->
     class { 'hhvm::package': } ->
     class { 'hhvm::config': 
-      settings => $settings,
+      settings => $_settings,
     } ->
     class { 'hhvm::service': } ->
   anchor { 'hhvm::end': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,9 +24,11 @@
 class hhvm (
   $manage_repos = true,
   $pgsql        = false,
+  $settings     = {},
 ) {
 
   validate_bool($manage_repos)
+  validate_hash($settings)
 
   if $manage_repos {
     anchor { 'hhvm::repo': } ->
@@ -36,7 +38,9 @@ class hhvm (
 
   anchor { 'hhvm::begin': } ->
     class { 'hhvm::package': } ->
-    class { 'hhvm::config': } ->
+    class { 'hhvm::config': 
+      settings => $settings,
+    } ->
     class { 'hhvm::service': } ->
   anchor { 'hhvm::end': }
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -16,6 +16,7 @@
 # See LICENSE file
 #
 class hhvm::package(
+  $ensure  = 'installed',
   $package = 'hhvm'
 ) {
 
@@ -26,6 +27,6 @@ class hhvm::package(
   validate_string($package)
 
   package { $package:
-    ensure => 'installed',
+    ensure => $ensure,
   }
 }


### PR DESCRIPTION
This pull request fixes 2 issues:
- the server.ini file is created with a default port (which isn't always necessary if hhvm is using a unix socket)
- the settings can now be passed in using hiera. 